### PR TITLE
call merge if the flake is used as a function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,7 @@
       f here rhs lhs;
   in
     with yants "data-merge"; {
+      __functor = self: self.merge;
       # ------
       # decorate
       # ------


### PR DESCRIPTION
Allows for using the input as a function, e.g.:
```nix
{
  inputs.merge.url = "github:divnix/data-merge";
  
  outputs = {merge, ...}: merge {/* someOutputs */} {/* someOtherOutputs */};
	
}
````