### PR TITLE
chore: adapt to namaka changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,15 +30,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1681604203,
-        "narHash": "sha256-oA/fW/85GmSNprghgAnZi0XeVMvW9xVuCYprzPw2hz0=",
+        "lastModified": 1683059428,
+        "narHash": "sha256-ZTMqleCWmuNWhZE375gtF1j1JRkaKEUFN1AM43e7h4Y=",
         "owner": "nix-community",
         "repo": "namaka",
-        "rev": "1550ddc025334cff2e8ec9021256473b2ffb27e5",
+        "rev": "2deba2f416454aec770bc1cc7365e39c73e6b1d7",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "v0.1.1",
         "repo": "namaka",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     inputs.nixpkgs.follows = "nixlib";
   };
   inputs.namaka = {
-    url = "github:nix-community/namaka";
+    url = "github:nix-community/namaka/v0.1.1";
     inputs.haumea.follows = "haumea";
     inputs.nixpkgs.follows = "nixlib";
   };
@@ -50,7 +50,7 @@
       };
     };
     checks = namaka.lib.load {
-      flake = self;
+      src = ./tests;
       inputs = res;
     };
   in


### PR DESCRIPTION
`flake` is deprecated in https://github.com/nix-community/namaka/commit/d0d17ed0fc3f34a74fc287267243aa503b0dd1f6 and will be remove in 0.2